### PR TITLE
hspcmp上の文法エラー強化

### DIFF
--- a/src/hspcmp/codegen.cpp
+++ b/src/hspcmp/codegen.cpp
@@ -2121,6 +2121,10 @@ void CToken::GenerateCodePP( char *buf )
 	//
 	int i;
 	GetTokenCG( GETTOKEN_DEFAULT );					// 最初の'#'を読み飛ばし
+	if (*cg_ptr != PickNextCodeCG()) {
+		// preprocesser command "#" 
+		throw CGERROR_UNKNOWN;
+	}
 	GetTokenCG( GETTOKEN_DEFAULT );
 
 	if ( ttype == TK_NONE ) {						// プリプロセッサから渡される行情報

--- a/src/hspcmp/codegen.cpp
+++ b/src/hspcmp/codegen.cpp
@@ -1337,7 +1337,17 @@ void CToken::CheckInternalProgCMD( int opt, int orgcs )
 		if ( ttype != TK_OBJ ) throw CGERROR_SYNTAX;
 		i = lb->Search( cg_str );
 		if ( i < 0 ) throw CGERROR_SYNTAX;
-		PutCS( lb->GetType(i), lb->GetOpt(i), EXFLG_2 );
+		{
+			int labelType = lb->GetType(i);
+			int labelOpt = lb->GetOpt(i);
+			if ((labelType == TYPE_PROGCMD) && (labelOpt == 0 || labelOpt == 1)) {
+				// goto or gosub
+				PutCS(labelType, labelOpt, EXFLG_2 );
+			}
+			else {
+				throw CGERROR_SYNTAX;
+			}
+		}
 		break;
 
 	case 0x08:					// await

--- a/src/hspcmp/codegen.cpp
+++ b/src/hspcmp/codegen.cpp
@@ -1275,6 +1275,7 @@ void CToken::CheckInternalListenerCMD( int opt )
 	t = lb->GetType(i);
 	o = lb->GetOpt(i);
 	if ( t != TYPE_PROGCMD ) return;
+	if ( o != 0x001 && o != 0x000 ) return;// not either gosub or goto
 	if ( o == 0x001 ) { // gosub
 		PutCS(t, o & 0xffff, 0);
 	}

--- a/src/hspcmp/codegen.cpp
+++ b/src/hspcmp/codegen.cpp
@@ -1350,14 +1350,14 @@ void CToken::CheckInternalProgCMD( int opt, int orgcs )
 	case 0x0d:					// dimtype
 	case 0x0e:					// dup
 	case 0x0f:					// dupptr
-		GetTokenCG( GETTOKEN_DEFAULT );
-		if ( ttype == TK_OBJ ) {
-			i = SetVarsFixed( cg_str, cg_defvarfix );
+		{
+			char *firstSymbolName = GetSymbolCG(cg_ptr);
+			if (firstSymbolName == NULL || isdigit(*reinterpret_cast<unsigned char *>(firstSymbolName)) ) break;
+			i = SetVarsFixed(firstSymbolName, cg_defvarfix );
 			//	変数の初期化フラグをセットする
 			lb->SetInitFlag( i, LAB_INIT_DONE );
 			//Mesf( "#initflag set [%s]", cg_str );
 		}
-		cg_ptr = cg_ptr_bak;
 		break;
 	}
 }

--- a/src/hspcmp/token.cpp
+++ b/src/hspcmp/token.cpp
@@ -851,6 +851,10 @@ int CToken::Calc( CALCVAR &val )
 		SetError("abnormal calculation");
 		return -1;
 	}
+	if (ttype != TK_NONE) {
+		SetError("expression syntax error");
+		return -1;
+	}
 	if ( wp==NULL ) { val = v; return 0; }
 	if ( *wp==0 ) { val = v; return 0; }
 	SetError("expression syntax error");

--- a/src/hspcmp/token.cpp
+++ b/src/hspcmp/token.cpp
@@ -748,41 +748,48 @@ void CToken::Calc_compare( CALCVAR &v )
 	int v1i,v2i,op;
 	Calc_addsub(v1);
 	while( (ttype=='<')||(ttype=='>')||(ttype=='=')) {
-		op=ttype; Calc_token();
+		op=ttype; 
 		if (op=='=') {
+			Calc_token();
 			Calc_addsub(v2);
 			v1i = v1==v2;
 			v1=(CALCVAR)v1i; continue;
 		}
 		if (op=='<') {
-			if ( ttype=='=' ) {
+			if ( *wp=='=' ) {
+				wp++;
 				Calc_token();Calc_addsub(v2);
 				v1i=(v1<=v2); v1=(CALCVAR)v1i; continue;
 			}
-			if ( ttype=='<' ) {
+			if ( *wp=='<' ) {
+				wp++;
 				Calc_token();Calc_addsub(v2);
 				v1i = (int)v1;
 				v2i = (int)v2;
 				v1i<<=v2i;
 				v1=(CALCVAR)v1i; continue;
 			}
+			Calc_token();
 			Calc_addsub(v2);
 			v1i=(v1<v2);
 			v1=(CALCVAR)v1i; continue;
 		}
 		if (op=='>') {
-			if ( ttype=='=' ) {
+			if ( *wp=='=' ) {
+				wp++;
 				Calc_token();Calc_addsub(v2);
 				v1i=(v1>=v2);
 				v1=(CALCVAR)v1i; continue;
 			}
-			if ( ttype=='>' ) {
+			if ( *wp=='>' ) {
+				wp++;
 				Calc_token();Calc_addsub(v2);
 				v1i = (int)v1;
 				v2i = (int)v2;
 				v1i>>=v2i;
 				v1=(CALCVAR)v1i; continue;
 			}
+			Calc_token();
 			Calc_addsub(v2);
 			v1i=(v1>v2);
 			v1=(CALCVAR)v1i; continue;


### PR DESCRIPTION
コンパイラ動作の修正を提案します。

１．#const、#enum等のプリプロセス実施の演算に関して
　　－　複数文字演算子の一部の間に空白文字を挟んで分離できる仕様をやめませんか？
　　　　(ex. )#const VAL1  1 < < 2 
　　－　行末に解釈不能なトークン単体が存在する際にエラーになるようにしませんか？
　　　　(ex.)#const VAL2 20 hoge
２．プリプロセス命令に関して
　　－　プリプロセス用プリフィックス(#)と命令文字列の間に空白文字の許可をやめませんか？
　　　　(ex.) #  define   NULL    0
　　－　プリプロセスで解釈されないものはコンパイラに移譲する方針で統一しませんか？
　　－　コンパイラは無効なプリプロセス命令に対してエラーを出すようにしませんか？
３．特定命令のコンパイル時の処理に関して
　　－　dim系命令の第一引数に文字列が渡された際の挙動を修正しませんか？
　　　　（常識的なランタイムの実装では実行時エラーになります）
　　－　on命令の後続における命令をgoto/gosubに限定しませんか？
　　　　(ex.) on result mes "a","b","c"
　　ー　buttonやoncmd等のジャンプ方式指定をgoto/gosub限定にしませんか？
　　　　（現状ではgosub以外のprogcmd命令がすべてgotoとして処理されています。）
　　　　(ex.) onexit repeat *clk

意図的な構文エラーを引き起こす目的で書かれたコードがコンパイル不能になる程度の弊害が生じます。
以上、よろしくお願いいたします。