### PR TITLE
fix an unexpected behavior of SPI controller

### DIFF
--- a/src/hsp3/linux/hsp3gr_linux.cpp
+++ b/src/hsp3/linux/hsp3gr_linux.cpp
@@ -293,6 +293,7 @@ int MCP3008_FullDuplex(int spich, int adcch){
   const uint8_t CHANNEL = adcch << 4;
   int res;
   struct spi_ioc_transfer tr;
+  memset(&tr, 0, sizeof(struct spi_ioc_transfer));
   uint8_t tx[COMM_SIZE] = {0, };
   uint8_t rx[COMM_SIZE] = {0, };
 

--- a/src/hsp3dish/raspbian/hsp3dish.cpp
+++ b/src/hsp3dish/raspbian/hsp3dish.cpp
@@ -974,6 +974,7 @@ int MCP3008_FullDuplex(int spich, int adcch){
   const uint8_t CHANNEL = adcch << 4;
   int res;
   struct spi_ioc_transfer tr;
+  memset(&tr, 0, sizeof(struct spi_ioc_transfer));
   uint8_t tx[COMM_SIZE] = {0, };
   uint8_t rx[COMM_SIZE] = {0, };
 


### PR DESCRIPTION
initialize spi_ioc_transfer in MCP3008 controller which was discussed [here](https://adaptive.u-aizu.ac.jp/gitlab/ome/ome2019/issues/13).