### PR TITLE
hspcmp のエラーハンドリングの微修正

### DIFF
--- a/src/hspcmp/membuf.cpp
+++ b/src/hspcmp/membuf.cpp
@@ -273,6 +273,7 @@ int CMemBuf::PutFile( char *fname )
 	fseek( ff,0,SEEK_END );
 	length=(int)ftell( ff );			// normal file size
 	fclose(ff);
+	if (length < 0) return -1;
 
 	p = PreparePtr( length+1 );
 	ff=fopen( fname,"rb" );


### PR DESCRIPTION
fname がディレクトリのとき不正なメモリ書き込みが生じてしまっていたので、エラー処理を追加しました。(例えば `hspcmp -h` とすると `fname="hsphelp/"` で呼ばれます。)