### PR TITLE
Ignore build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@
 __hsptmp.*
 .hspres
 
+# Built outputs
+*.a
+/hsed
+/hsp3cl
+/hsp3dish
+/hsp3gp
+/hspcmp
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
コミットしないファイルがGitに変更としてみなされないようにします。