### PR TITLE
socket 関係のコマンドが "サポートされない機能を選択しました" エラーで使用できない不具合の修正

### DIFF
--- a/common/dish_enhance.as
+++ b/common/dish_enhance.as
@@ -7,7 +7,7 @@
 ;
 ;	Socket Enhance
 ;
-#regcmd 18
+#regcmd 19
 #cmd sockopen $60
 #cmd sockclose $61
 #cmd sockreadbyte $62

--- a/src/hsp3/linux/hsp3cl.cpp
+++ b/src/hsp3/linux/hsp3cl.cpp
@@ -209,7 +209,8 @@ int hsp3cl_init( char *startfile )
 
 	exinfo = ctx->exinfo2;
 
-	HSP3TYPEINFO *tinfo = code_gettypeinfo( -1 ); //TYPE_USERDEF
+	// FIXME: Define another C_TYPE macro at `src/hsp3/hsp3struct.h` or in other ways
+	HSP3TYPEINFO *tinfo = code_gettypeinfo( TYPE_USERDEF+1 );
 	tinfo->hspctx = ctx;
 	tinfo->hspexinfo = exinfo;
 	hsp3typeinit_sock_extcmd( tinfo );

--- a/src/hsp3dish/linux/hsp3dish.cpp
+++ b/src/hsp3dish/linux/hsp3dish.cpp
@@ -737,8 +737,9 @@ int hsp3dish_init( char *startfile )
 	}
 #endif
 
+	// FIXME: Define another C_TYPE macro at `src/hsp3/hsp3struct.h` or in other ways
 	{
-	HSP3TYPEINFO *tinfo = code_gettypeinfo( -1 ); //TYPE_USERDEF
+	HSP3TYPEINFO *tinfo = code_gettypeinfo( -1 ); //TYPE_USERDEF+1
 	tinfo->hspctx = ctx;
 	tinfo->hspexinfo = exinfo;
 	hsp3typeinit_sock_extcmd( tinfo );

--- a/src/hsp3dish/raspbian/hsp3dish.cpp
+++ b/src/hsp3dish/raspbian/hsp3dish.cpp
@@ -35,6 +35,7 @@
 #include "../sysreq.h"
 //#include "../hsp3ext.h"
 #include "../../hsp3/strnote.h"
+#include "../../hsp3/linux/hsp3ext_sock.h"
 
 #include "../emscripten/appengine.h"
 
@@ -815,6 +816,14 @@ int hsp3dish_init( char *startfile )
 	hsp3typeinit_dw_extcmd( tinfo );
 	//hsp3typeinit_dw_extfunc( code_gettypeinfo( TYPE_USERDEF+1 ) );
 #endif
+
+	{
+	// FIXME: Define another C_TYPE macro at `src/hsp3/hsp3struct.h` or in other ways
+	HSP3TYPEINFO *tinfo = code_gettypeinfo( -1 ); //TYPE_USERDEF+1
+	tinfo->hspctx = ctx;
+	tinfo->hspexinfo = exinfo;
+	hsp3typeinit_sock_extcmd( tinfo );
+	}
 
 	//		Initalize DEVINFO
 #ifdef DEVCTRL_IO


### PR DESCRIPTION
hsp3dish にて、socket 関係のコマンドを使用するとランタイムが "サポートされない機能を選択しました" というエラーメッセージとともに異常終了します。

## 再現するコードと実行結果

```
; socktest.hsp
#include "hsp3dish.as"

sockopen 0, "127.0.0.1", 8000
end
```
```
$ ./hspcmp -i -d -u socktest.hsp
#HSP script preprocessor ver3.6beta5 / onion software 1997-2021(c)
#Use file [hspdef.as]
#Use file [dish_enhance.as]
#HSP code generator ver3.6beta5 / onion software 1997-2021(c)
#use UTF-8 strings.
#Code size (32) String data size (67) param size (0)
#Vars (0) Labels (1) Modules (0) Libs (0) Plugins (3)
#No error detected. (total 978 bytes)

$ ./hsp3dish ./socktest.ax
Init:HGIOScreen(640,480)
#Error 21 in line 3 (socktest.hsp)
-->サポートされない機能を選択しました
```

## 修正内容
オブジェクトファイルにてコマンドの識別子に付与されるコマンドタイプが、socket 関係のコマンドのものと OBAQ 関係のコマンドのもので重複しており、結果 socket 関係のコマンドの定義がランタイムに登録されないことを確認したので、socket 関係のコマンドタイプを 19 (`TYPE_USERDEF` + 1) に変更しました。

x86_64 の linux と raspberry pi にて、hsp3cl で `sockopen` が動作することを、hsp3dish で `sockopen` と `qreset`、`qexec`、`qdraw` が実行できることを確認しました。