### PR TITLE
make.raspbianの変更

### DIFF
--- a/makefile.raspbian
+++ b/makefile.raspbian
@@ -87,7 +87,7 @@ OBJS_CL = \
 	src/hsp3/linux/hsp3cl.o \
 	src/hsp3/linux/hsp3ext_linux.o \
 	src/hsp3/linux/hsp3ext_sock.o \
-	src/hsp3/linux/devctrl_io.do \
+	src/hsp3/linux/devctrl_io.o \
 	src/hsp3/linux/hsp3gr_linux.o
 
 TARGETS = hsp3dish hsp3cl hspcmp hsed


### PR DESCRIPTION
makefile.raspbianのファイルのなかにOJSC_CLに代入されるファイルがsrc/hsp3/linux/devctrl_io.doでほかは*.oだったので<br>
src/hsp3/linux/devctrl_io.oに変更しました。<br>
`hsp3cl.as`をインクルードした際のgpioin関数が0だけの出力の状態がなくなりました。<br>よってmakefile.raspbianの90行目src/hsp3/linux/devctrl_io.do→src/hsp3/linux/devctrl_io.oの通りに変更しました。<br>