### PR TITLE
Fix emscripten

### DIFF
--- a/src/hsp3dish/emscripten/hsp3dish.cpp
+++ b/src/hsp3dish/emscripten/hsp3dish.cpp
@@ -327,6 +327,11 @@ static void hsp3dish_initwindow( engine* p_engine, int sx, int sy, char *windowt
 		return;
 	}
 
+	char *env_keyboard_element = getenv( "HSP_KEYBOARD_ELEMENT" );
+	if (env_keyboard_element) {
+		SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, env_keyboard_element);
+	}
+
 	window = SDL_CreateWindow( "HSPDish ver" hspver, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, sx, sy, SDL_WINDOW_OPENGL );
 	if ( window==NULL ) {
 		printf("Unable to set window: %s\n", SDL_GetError());

--- a/src/hsp3dish/emscripten/hsp3dish.cpp
+++ b/src/hsp3dish/emscripten/hsp3dish.cpp
@@ -185,7 +185,7 @@ static int handleEvent( void ) {
 		case SDL_KEYDOWN:
 			{
 			int wparam = 0;
-			int code = (int)event.key.keysym.sym;
+			int code = (int)event.key.keysym.scancode;
 			if (code < SDLK_SCANCODE_MAX) {
 				keys[code] = true;
 			}
@@ -285,8 +285,8 @@ static int handleEvent( void ) {
 			break;
 			}
 		case SDL_KEYUP:
-			if (event.key.keysym.sym < SDLK_SCANCODE_MAX) {
-				keys[event.key.keysym.sym] = false;
+			if (event.key.keysym.scancode < SDLK_SCANCODE_MAX) {
+				keys[event.key.keysym.scancode] = false;
 			}
 			//printf("key up: sym %d scancode %d\n", event.key.keysym.sym, event.key.keysym.scancode);
 			break;

--- a/src/hsp3dish/emscripten/hsp3dish.cpp
+++ b/src/hsp3dish/emscripten/hsp3dish.cpp
@@ -35,6 +35,7 @@
 #include "SDL2/SDL_opengl.h"
 
 #include <emscripten.h>
+#include <emscripten/html5.h>
 
 //#define USE_OBAQ
 
@@ -565,6 +566,15 @@ static void hsp3dish_setdevinfo( HSP3DEVINFO *devinfo )
 	devinfo->devinfoi = hsp3dish_devinfoi;
 }
 
+static EM_BOOL hsp3dish_em_mouse_callback(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData)
+{
+	// デフォルト動作ではpreventDefault()されてフォーカスがあたらないので手動でフォーカスを要求する
+	EM_ASM_({
+		Module.canvas.focus();
+	});
+	return false;
+}
+
 /*----------------------------------------------------------*/
 
 int hsp3dish_init( char *startfile )
@@ -760,6 +770,9 @@ int hsp3dish_init( char *startfile )
 	HSP3DEVINFO *devinfo;
 	devinfo = hsp3extcmd_getdevinfo();
 	hsp3dish_setdevinfo( devinfo );
+
+    // イベントハンドラ追加
+    emscripten_set_mousedown_callback("#canvas", nullptr, true, hsp3dish_em_mouse_callback);
 
 	return 0;
 }

--- a/src/hsp3dish/makefile.emscripten
+++ b/src/hsp3dish/makefile.emscripten
@@ -8,6 +8,7 @@ CFLAGS_CORE = -Wall -DNDEBUG -DHSPDISH -DHSPEMSCRIPTEN -DHSPDEBUG \
 	   -fpermissive -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 \
 	   -s "EXTRA_EXPORTED_RUNTIME_METHODS=['addRunDependency', 'removeRunDependency', 'FS_createPreloadedFile', 'FS_createPath']" \
 	   -s DISABLE_EXCEPTION_CATCHING=0 \
+	   -lidbfs.js \
 	   --memory-init-file 0
 CFLAGS_DEBUG =
 #CFLAGS_DEBUG = -g3 --js-opts 0

--- a/src/hsp3dish/texmes.cpp
+++ b/src/hsp3dish/texmes.cpp
@@ -378,9 +378,11 @@ unsigned char* texmesManager::texmesGetFont(char* msg, int* out_sx, int* out_sy,
 	int sx, sy, size;
 	int pitch,tsx,tsy;
 
+#if !defined(HSPEMSCRIPTEN)
 	if (info) {
 		info->length = 0;
 	}
+#endif
 
 	hgio_fontsystem_exec(msg, NULL, 0, &sx, &sy, info);
 


### PR DESCRIPTION
hsp3dish.jsのキーボード入力関連処理を変更しました。
stickが機能していない件の修正とキーボード関連のイベントリスナーを設定する範囲を設定する環境変数の追加です。

全画面ゲーム以外でHTMLフォームなどと混在したい場合に、
ENV.HSP_KEYBOARD_ELEMENT = "#canvas";
のような指定でメインのHSPのキャンバス以外のイベントは無視できるようにしたいという意図です。

経緯としてはこのスレッドの日本語入力できないかという話です。
http://hsp.tv/play/pforum.php?mode=all&num=95742