### PR TITLE
hsc_comp関数のモードの処理を修正

### DIFF
--- a/src/hspcmp/win32dll/hspcmp3.cpp
+++ b/src/hspcmp/win32dll/hspcmp3.cpp
@@ -266,7 +266,7 @@ EXPORT BOOL WINAPI hsc_comp ( int p1, int p2, int p3, int p4 )
 	strcat( fname2, ".i" );
 	hsc3->SetCommonPath( compath );
 	ppopt = 0;
-	if ( p1 ) ppopt|=HSC3_OPT_DEBUGMODE;
+	if ( p1&1 ) ppopt|=HSC3_OPT_DEBUGMODE;
 	if ( p2&1 ) ppopt|=HSC3_OPT_NOHSPDEF;
 	if ( p2&4 ) ppopt|=HSC3_OPT_MAKEPACK;
 	if ( p2&8 ) ppopt|=HSC3_OPT_READAHT;


### PR DESCRIPTION
hsc_comp関数の第一引数 (モードのビットフラグ) で、1以外のフラグを指定したときもデバッグモードのフラグが有効とみなされてしまっていたので、修正しました