### PR TITLE
mcurlの解放漏れでLinux版で2回目以降のhsploadが失敗していた

### DIFF
--- a/src/hsp3dish/linux/webtask_linux.cpp
+++ b/src/hsp3dish/linux/webtask_linux.cpp
@@ -197,8 +197,8 @@ int WebTask::Exec( void )
 			mode = CZHTTP_MODE_VARDATAEND;
 		} else {
 			//printf("curle error\n");
-		        char buffer[256];
-		        sprintf(buffer, "ダウンロード中にエラーが発生しました(%d:%s)", ret, curl_easy_strerror(ret));
+			char buffer[256];
+			snprintf(buffer, sizeof(buffer), "ダウンロード中にエラーが発生しました(%d:%s)", ret, curl_easy_strerror(ret));
 			SetError(buffer);
 		}
 #else
@@ -210,14 +210,16 @@ int WebTask::Exec( void )
 	case CZHTTP_MODE_VARDATAWAIT:
 		ret = curl_multi_perform(mcurl, &running);
 		if (ret != CURLM_OK && ret != CURLM_CALL_MULTI_PERFORM) {
-		        char buffer[256];
-		        sprintf(buffer, "ダウンロード中にエラーが発生しました(%d:%s)", ret, curl_multi_strerror(ret));
+			curl_multi_remove_handle(mcurl, curl);
+			char buffer[256];
+			snprintf(buffer, sizeof(buffer), "ダウンロード中にエラーが発生しました(%d:%s)", ret, curl_multi_strerror(ret));
 			SetError(buffer);
 			break;
 		}
 		if (running == 0) {
 			struct CURLMsg *m;
 
+			curl_multi_remove_handle(mcurl, curl);
 			mode = CZHTTP_MODE_VARDATAEND;
 			break;
 		}

--- a/src/hsp3dish/linux/webtask_linux.cpp
+++ b/src/hsp3dish/linux/webtask_linux.cpp
@@ -323,7 +323,7 @@ size_t WebTask::OnReceive(char* ptr, size_t size, size_t nmemb, void* stream) {
 	WebTask* web = (WebTask*) stream;
 	const size_t sizes = size * nmemb;
 
-	size_t needed_size = size + sizes;
+	size_t needed_size = web->size + sizes;
 	if ( needed_size > web->varsize ) {
 		while ( needed_size > web->varsize ) {
 			web->varsize *= 2;


### PR DESCRIPTION
公式BBSのこの件の対応です。
http://hsp.tv/play/pforum.php?mode=all&num=101650

```hsp
#include "hsp3dish.as"

	url="[http://www.onionsoft.net/img/onibtn.gif"](http://www.onionsoft.net/img/onibtn.gif%22)
	fname ="onibtn.gif"		//1回目の保存ファイル名
	fname2 ="onibtn2.gif"	//2回目の保存ファイル名
	times = 0

*loadset
	times++
	httpload url
	if stat : goto *bad	//正しくリクエストができなかった

*main
	//結果待ちのためのループ
	httpinfo res,HTTPINFO_MODE
	if res = HTTPMODE_READY : goto *comp
	if res <= HTTPMODE_NONE : goto *bad
	await 50
	goto *main

*bad
	//エラー
	httpinfo estr,HTTPINFO_ERROR
	dialog "ERROR "+estr
	stop

*comp
	//DOWNLOAD 完了
	httpinfo buf,HTTPINFO_DATA
	httpinfo size,HTTPINFO_SIZE

	if times == 1{
		bsave fname,buf,size
		redraw 0
		color 0,0,0:pos 0,0
		mes "["+fname+"] saved."
		redraw 1
		await 1000
		goto *loadset
	}
	if times == 2{
		bsave fname2,buf,size
		redraw 0
		color 0,0,0:pos 0,0
		mes "["+fname2+"] saved."
		redraw 1
		await 1000
		stop
	}
```