### PR TITLE
SPI で全二重通信をするためのインターフェースを追加

### DIFF
--- a/doclib/hsp3linux_pi.html
+++ b/doclib/hsp3linux_pi.html
@@ -221,6 +221,51 @@ Raspberry Pi版では、フルスクリーンで実行を行ないます。 実�
 		</p>
 
 
+		<h2 id="DATA">Raspberry PiのSPI入出力</h2>
+		<p>
+		Raspberry Pi版では、devcontrol(spi～)命令によりI2Cデバイスとの入出力を行なう拡張が行われています。<br>
+		SPI制御を行う場合は、RaspberryPiのオプション設定でSPIをEnableにする必要があります。(SPI制御を行なわない場合は、設定の必要ありません) SPI制御を行う場合は、以下のように記述します。
+		</p><pre>
+	devcontrol "spiopen", バス番号, チップセレクト, チャンネル
+		「チャンネル」は複数のデバイスを同時に指定する場合に識別を行う番号です。(0～31の整数値)
+		単一のデバイスを制御する場合は省略(0)して構いません。
+		バス番号セレクトとチップセレクトはデバイスファイルへのパス<code>/dev/spidev&lt;バス番号&gt;.&lt;チップセレクト&gt;</code>に対応し、
+		指定したデバイスファイルに対応するデバイスを制御できるようになります。
+		結果がシステム変数statに返ります。0の場合は成功、それ以外はエラーになります。
+		</pre><p>
+		データを送受信する場合は、以下のように記述します。
+		</p><pre>
+	devcontrol "spitransceive", データ値, データサイズ, チャンネル
+		データ値は、HSPが扱う32bitの整数値になります。
+		データサイズが0または省略した場合は、8bit(1byte)のみ出力されます。
+		データサイズは、1,2,3が指定できます。それぞれ、1～3byteのサイズが送信・受信されます。
+		送受信は同時に行われます。
+		命令の実行後に指定したサイズの受信データがシステム変数statに結果が代入されます。（エラーが発生した場合は、マイナス値が代入されます）。
+		ビッグエンディアン環境で使用する場合は上位3 byteがデータを、下位1 byteがエラーを表します。
+		SPI制御は、hsp3dishだけでなくhsp3clからも使用することが可能です。
+		</pre><p>
+		SPI デバイスドライバに対して設定が必要な場合は、<code>spiconfigureh</code>、<code>spiconfighrem</code>、<code>spiconfigurel</code>、加えて<code>spisetmode</code>、<code>spisetmode32</code>、<code>spisetlsbfirst</code>、<code>spisetbitsperword</code>、<code>spisetmaxspeedhz</code>を使用します。それぞれ以下のように記述します。
+		</p><pre>
+	devcontrol "spiconfigureh", SPEED_HZ, DELAY_USECS, BITS_PER_WORD
+	devcontrol "spiconfighrem", CS_CHANGE, TX_NBITS, RX_NBITS
+	devcontrol "spiconfighrel", WORD_DELAY_USECS
+	devcontrol "spisetmode", MODE, チャンネル
+	devcontrol "spisetmode32", MODE, チャンネル
+	devcontrol "spisetlsbfirst", LSB_FIRST, チャンネル
+	devcontrol "spisetbitsperword", BITSPERWORD, チャンネル
+	devcontrol "spisetmaxspeedhz", SPEED_HZ, チャンネル
+		<code>SPEED_HZ</code> でクロック周波数を設定します。
+		<code>DELAT_USECS</code> に非ゼロを設定すると最終ビット送信と次のバイト送信の間にマイクロ秒単位の遅延を挿入します。
+		<code>BITS_PER_WORD</code> でデバイスのワードサイズを設定します。
+		<code>CS_CHANGE</code> に非ゼロを設定すると通信の後にチップセレクトを非アクティブ化しません。
+		<code>TX_NBITS</code> で書き込みのデータ線本数を指定します。0 でシングルモードになります。デュアル、クアッドモードに設定する場合ホストのヘッダーから <code>SPI_TX_DUAL</code>、<code>SPI_TX_QUAD</code> が参照する値を設定してください。
+		<code>RX_NBITS</code> で読み込み時のデータ線本数を指定します。0 でシングルモードになります。デュアル、クアッドモードに設定する場合ホストのヘッダーから <code>SPI_RX_DUAL</code>、<code>SPI_RX_QUAD</code> が参照する値を設定してください。
+		<code>WORD_DELAY_USECS</code> でワード間の遅延をマイクロ秒単位で設定します。
+		<code>MODE</code> に0&mdash;3を設定するとSPIの動作モードがそれぞれモード0、...、モード3 に設定されます。
+		<code>LSB_FIRST</code>にゼロを設定するとMSB先行モードに、非ゼロを設定するとLSB先行モードになります。
+		</pre>
+
+
 		<h2 id="COPYRIGHT">著作権とライセンス</h2>
 		<p>
 		HSP3 for Linux/Raspberry Piは、OpenHSPの派生物として取り扱い、ライセンスもOpenHSP/HSP3に準拠した修正BSDライセンスとなります。

--- a/doclib_en/hsp3linux_pi.html
+++ b/doclib_en/hsp3linux_pi.html
@@ -221,6 +221,53 @@ The result is assigned to the system variable stat after the instruction is exec
 		</p>
 
 
+		<h2 id="DATA">Raspberry Pi SPI input / output</h2>
+		<p>
+		In the Raspberry Pi version, the extension to input / output with the SPI device is done by the devcontrol (spi ~) command. <br>
+		For SPI control, SPI must be enabled in the Raspberry Pi option settings. (If SPI control is not performed, no setting is required.) When SPI control is performed, describe as follows.
+		</p><pre>
+	devcontrol "spiopen", bus number, chip select, channel
+		"Channel" is a number that identifies when multiple devices are specified at the same time. (Integer value from 0 to 31)
+		It can be omitted (0) when controlling a single device.
+		spiopen will enable control of the SPI device at the corresponding device file as <code>/dev/spidev&lt;bus number&gt;.&lt;chip select&gt;</code>.
+		The result is returned in the system variable stat. If it is 0, it will be successful, otherwise it will be an error.
+		</pre><p>
+		To send and receive data, write as follows.
+		</p><pre>
+	devcontrol "spitransceive", data value, data size, channel
+		The data value is a 32-bit integer value handled by HSP.
+		If the data size is 0 or omitted, only 8bit (1byte) is output.
+		The data size can be 1,2, and 3. The size of 1 to 3 bytes is output for each.
+		Transmission performs in the full-duplex manner.
+		The received data is assigned to the system variable stat after the instruction is executed.
+		Values received first come to lower bytes and negative values represents
+		any errors occured in little endian-environment.
+		Higher 3 bytes represents data and lower 1 byte represents errors in big endian-environment.
+		SPI control can be used not only from hsp3dish but also from hsp3cl.
+		</pre><p>
+		<code>spiconfigureh</code>,<code>spiconfighrem</code>,<code>spiconfigurel</code>,<code>spisetmode</code>,<code>spisetmode32</code>,<code>spisetlsbfirst</code>,<code>spisetbitsperword</code>, and <code>spisetmaxspeedhz</code> can be used to configure SPI device drivers.
+		</p><pre>
+	devcontrol "spiconfigureh", SPEED_HZ, DELAY_USECS, BITS_PER_WORD
+	devcontrol "spiconfighrem", CS_CHANGE, TX_NBITS, RX_NBITS
+	devcontrol "spiconfighrel", WORD_DELAY_USECS
+	devcontrol "spisetmode", MODE, channel
+	devcontrol "spisetmode32", MODE, channel
+	devcontrol "spisetlsbfirst", LSB_FIRST, channel
+	devcontrol "spisetbitsperword", BITSPERWORD, channel
+	devcontrol "spisetmaxspeedhz", SPEED_HZ, channel
+		where
+		<code>SPEED_HZ</code> sets clock frequency in Hz.
+		<code>DELAT_USECS</code> sets delay between last bit transmission and next byte transmission in micro seconds.
+		<code>BITS_PER_WORD</code> sets word size for the device.
+		Non-zero <code>CS_CHANGE</code> keep chiselect activated after the execution of spitransceive.
+		<code>TX_NBITS</code> sets the number of data lines to send. 0 indicates single mode. Refer the values of <code>SPI_TX_DUAL</code> and <code>SET_TX_QUAD</code> from host headers to enable DUAL or QUAD modes.
+		<code>RX_NBITS</code> sets the number of data lines to receive. 0 indicates single mode. Refer the values of <code>SPI_RX_DUAL</code> and <code>SET_RX_QUAD</code> from host headers to enable DUAL or QUAD modes.
+		<code>WORD_DELAY_USECS</code> sets delays between words in micro seconds.
+		Setting <code>MODE</code> 0&mdash;3 changes SPI operation modes into mode0&mdash;mode3.
+		Set <code>LSB_FIRST</code> zero to enable the MSB-first mode, non-zero to enable the LSB-first mode.
+		</pre>
+
+
 <h2 id = "COPYRIGHT"> Copyright and license </h2>
 		<p>
 HSP3 for Linux / Raspberry Pi is treated as a derivative of OpenHSP, and the license is also a modified BSD license compliant with OpenHSP / HSP3.


### PR DESCRIPTION
SPI で全二重通信をするためのインターフェースを追加しました。
SPI による全二重通信をリクエストする関数 (`SPI_Transceive`)
と、リクエストに付与するパラメータを設定する関数
(`SPI_Configure{H,M,L}`)、加えて SPI ドライバのパラメータを
変更する関数

- SPI_{RD,WR}_MODE
- SPI_{RD,WR}_MODE32
- SPI_{RD,WR}_LSB_FIRST
- SPI_{RD,WR}_BITS_PER_WORD
- SPI_{WD,WR}_MAX_SPEED_HZ

を追加しました。これに伴い、
MCP3008 の専用実装を削除しました。

詳細
====
これまでの OpenHSP の SPI サポートは
read/write システムコールによるものに限られており、
したがって半二重通信のみがサポートされていました
(read/write では全二重通信はできない [1])。
しかし SPI はデータ線が 2 本あり、
いくつかの SPI デバイスは全二重通信による通信を要求します。
その場合は HSP ランタイムに専用実装を埋め込んでいる
状況でした。

たとえば Microchip 社の ADC である MCP3008 [2] は
3 bytes 単位で通信を行いデータをやり取りしますが、
マスターは 2 byte 目でデバイスに対しコマンドを送信しつつ
2 byte 目の 7 bit 目からデータの受信を
開始する必要があります。
これは厳密には全二重通信とは言わないかもしれませんが、
read/write システムコールは 8 bit 単位での
半二重通信を行うため 2 byte 目を write() している間は
7, 8 bit 目を read() することができません。
完全なデータのやり取りをするには IOCTL による
全二重通信が必要になります。

この commit は HSP スクリプトからアクセスできる汎用的で
全二重通信 (IOCTL 経由) 可能な SPI インターフェースを
追加します。また IOCTL で全二重通信 (`SPI_IOC_MESSAGE(N)`)
をリクエストするときに必要なパラメータ
`struct spi_ioc_transfer` を設定する関数も追加しました。
この構造体に設定すべきパラメータは 7 個ある一方、
devcontrol は引数を 3 個までしか受け付けないようなので
関数は 3 個に分けて実装しました
(`SPI_Configure_H` for higher 3 fields, `SPI_Configure_M` for middle 3 fields,, `SPI_Configure_L` for the last field)。 最後に、転送モード等のSPI ドライバの設定 [1] を
変更するための関数も追加しました。
特に転送モードは `SPI_IOC_MESSAGE(N)` のパラメータで、
temporarily に変更できないため必要です。

これに伴い、ランタイムに含まれていたデバイスごとの
専用実装を削除しました。

動作確認
========
Raspberry Pi OS Bookworm が動作する Raspberry Pi 400
にて hsp3dish, hsp3cl 両方のランタイムで MCP3008 と
通信できることを確認しました。

https://github.com/RollMan/hsp_spi_pr_test_by_mcp3008/commit/a0cfab4bcd83e6310fbdc894e6889748656e70fa

例
==

```
; Configure spidev options
devcontrol "spisetmaxspeedhz", 10000, ch
devcontrol "spisetmode", 0, ch
devcontrol "spisetlsbfirst", 0, ch
devcontrol "spisetbitsperword", 8, ch
devcontrol "spiconfigureh", 10000, 0, 8
devcontrol "spiconfigurem", 1, 0, 0	; Keep selecting the device for the 3-bytes command
devcontrol "spiconfigurel", 0

; Start communication
;; Prepare a buffer as {dont care, upper 2 bits of data, lower 8 bits of data}
dim recv, 3
;; Send start byte
devcontrol "spitransceive", 1, 1, ch
byte(0) = stat
;; Send control byte: SINGLE_ENDED (0x80) | adc_pin.
;; In bit-wire sepresentation, {single/diff, adc_pin[2], adc_pin[1], adc_pin[0], x, x, x}
SIGNLE_ENDED = 0x80
devcontrol "spitransceive", SINGLE_ENDED | (adc_pin << 4), 1, ch
byte(1) = stat
;; Send an empty byte (avoiding start byte 0x01) and receive rest data.
devcontrol "spiconfigurem", 0, 0, 0	; Deselect the device
devcontrol "spitransceive", 0x00, 1, ch
byte(2) = stat
res = ((0x03 & byte(1)) << 8) | byte(2)
mes res
```

参考
====
- [1] https://www.kernel.org/doc/Documentation/spi/spidev
- [2] https://www.microchip.com/en-us/product/mcp3008
- https://codebrowser.dev/linux/linux/include/uapi/linux/spi/spi.h.html
- https://codebrowser.dev/linux/linux/include/uapi/linux/spi/spidev.h.html