### PR TITLE
makefile で使用する pkg-config をハードコードから変数に変更

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ CFLAGS_DISH = -Wno-write-strings --exec-charset=UTF-8 -DHSPDISH -DHSPLINUX -DHSP
 CFLAGS_GP = -Wno-write-strings --exec-charset=UTF-8 -DHSPDISH -DHSPDISHGP -DHSPLINUX -DHSPDEBUG -DPNG_ARM_NEON_OPT=0 -I src/hsp3dish/extlib/src -I src/hsp3dish/extlib/src/glew -I src/hsp3dish/gameplay/src -std=c++11
 CFLAGS_CL = -Wno-write-strings -std=c++11 --exec-charset=UTF-8 -DHSPLINUX -DHSPDEBUG
 CFLAGS_CMP = -Wno-write-strings -std=c++11 --exec-charset=UTF-8 -DHSPLINUX -DHSPDEBUG
+PKG_CONFIG = pkg-config
 
 OBJS = \
 	src/hsp3/dpmread.do \
@@ -448,7 +449,7 @@ hsp3cl: $(OBJS_CL)
 	$(CXX) $(CFLAGS_CL) -c $< -o $*.o
 
 hsed: src/tools/hsed_gtk2.cpp src/tools/supio.cpp
-	$(CXX) -O2 -Wno-write-strings -o hsed src/tools/hsed_gtk2.cpp src/tools/supio.cpp `pkg-config --cflags --libs gtk+-2.0`
+	$(CXX) -O2 -Wno-write-strings -o hsed src/tools/hsed_gtk2.cpp src/tools/supio.cpp `$(PKG_CONFIG) --cflags --libs gtk+-2.0`
 
 libgameplay.a: $(OBJS_GAMEPLAY)
 	rm -f $@

--- a/makefile.raspbian
+++ b/makefile.raspbian
@@ -6,6 +6,7 @@ CFLAGS_GP =  -Wno-write-strings -fpermissive --exec-charset=UTF-8 -DHSPDISH -DHS
 LDFLAGS= -lm -L$(SDKSTAGE)/opt/vc/lib/ -lbrcmGLESv2 -lbrcmEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lSDL2 -lSDL2_mixer -lSDL2_ttf -lcurl
 CFLAGS_CL =  -Wno-write-strings -std=c++11 --exec-charset=UTF-8 -DHSPLINUX -DHSPDEBUG -DHSPRASPBIAN
 CFLAGS_CMP =  -Wno-write-strings -std=c++11 --exec-charset=UTF-8 -DHSPLINUX -DHSPDEBUG
+PKG_CONFIG = pkg-config
 
 OBJS = \
 	src/hsp3/dpmread.do \
@@ -122,7 +123,7 @@ hsp3cl: $(OBJS_CL)
 	$(CXX) $(CFLAGS_CL) -c $< -o $*.o
 
 hsed: src/tools/hsed_gtk2.cpp src/tools/supio.cpp
-	$(CXX) -O2 -Wno-write-strings -DHSPRASPBIAN -o hsed src/tools/hsed_gtk2.cpp src/tools/supio.cpp `pkg-config --cflags --libs gtk+-2.0`
+	$(CXX) -O2 -Wno-write-strings -DHSPRASPBIAN -o hsed src/tools/hsed_gtk2.cpp src/tools/supio.cpp `$(PKG_CONFIG) --cflags --libs gtk+-2.0`
 
 clean:
 	rm -f $(OBJS) $(OBJS_CMP) $(OBJS_CL) $(TARGETS)


### PR DESCRIPTION
makefile で pkg-config を使用していますが、これを変数にしました。環境変数から使用する pkg-config をオーバーライドできるのでクロスコンパイルするときなどに便利です。

例・動作確認
============
amd64 Linux で aarch64 (arm64) Linux を
ターゲットにクロスコンパイル:

```
make -j6 \
CC=aarch64-linux-gnu-gcc \
CXX=aarch64-linux-gnu-g++ \
AR=aarch64-linux-gnu-ar \
PKG_CONFIG=aarch64-linux-gnu-pkg-config \
hsp3cl hsp3dish hspcmp
```