### PR TITLE
[CI] aptでinstall前にupdateを呼ぶ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install libraries
-      run: sudo apt install -y libgtk2.0-dev libglew-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libgles2-mesa-dev libegl1-mesa-dev libcurl4-openssl-dev libgpiod2 libgpiod-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgtk2.0-dev libglew-dev libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libgles2-mesa-dev libegl1-mesa-dev libcurl4-openssl-dev libgpiod2 libgpiod-dev
     - name: make
       run: make -j2
     - name: Archive production artifacts


### PR DESCRIPTION
apt-get updateを先に呼ばないとapt-get installが404で失敗するようになってました。