### PR TITLE
Remove cast warnings.

### DIFF
--- a/src/hsp3/hsp3code.cpp
+++ b/src/hsp3/hsp3code.cpp
@@ -2189,7 +2189,7 @@ static int cmdfunc_prog( int cmd )
 		if ( p2<=0 ) throw HSPERR_ILLEGAL_FUNCTION;
 		if ( HspVarCoreGetProc(p3)->flag == 0 ) throw HSPERR_ILLEGAL_FUNCTION;
 		if (pval_m->support & HSPVAR_SUPPORT_FIXEDVALUE) throw HSPERR_FIXED_VARVALUE;
-		HspVarCoreDupPtr( pval_m, p3, (void *)p1, p2 );
+		HspVarCoreDupPtr( pval_m, p3, (void *)((intptr_t)p1), p2 );
 		break;
 		}
 


### PR DESCRIPTION
下記の警告を削除します。

---

```console
0.308 src/hsp3/hsp3code.cpp: In function 'int cmdfunc_prog(int)':
0.308 src/hsp3/hsp3code.cpp:2192:41: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
0.308    HspVarCoreDupPtr( pval_m, p3, (void *)p1, p2 );
0.308                                          ^~
```

---

コンパイラ

```console
g++ (GCC) 7.3.1 20180712 (Red Hat 7.3.1-17)
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
