### PR TITLE
Fix uninitialized fname access when copying absolute path.

### DIFF
--- a/src/hsp3/dpmread.cpp
+++ b/src/hsp3/dpmread.cpp
@@ -165,17 +165,20 @@ int dpm_filecopy( char *fname, char *sname )
 	fp2=fopen(sname,"wb");if (fp2==NULL) return 1;
 #endif
 	fp1 = filepack.pack_fopen(fname);
-	if (fp1 == NULL) return -1;
+	if (fp1 == NULL) {
+		fclose(fp2);
+		return -1;
+	}
 
-		mem=(char *)mem_ini(max);
-		while(1) {
-			if (flen==0) break;
-			if (flen<max) xlen=flen; else xlen=max;
-			filepack.pack_fread(fp1, mem, xlen);
-			fres = (int)fwrite( mem, 1, xlen, fp2 );
-			if (fres<xlen) break;
-			flen-=xlen;
-		}
+	mem=(char *)mem_ini(max);
+	while(1) {
+		if (flen==0) break;
+		if (flen<max) xlen=flen; else xlen=max;
+		filepack.pack_fread(fp1, mem, xlen);
+		fres = (int)fwrite( mem, 1, xlen, fp2 );
+		if (fres<xlen) break;
+		flen-=xlen;
+	}
 
 	filepack.pack_fclose(fp1);
 	fclose(fp2);

--- a/src/hsp3/filepack.cpp
+++ b/src/hsp3/filepack.cpp
@@ -443,7 +443,10 @@ int FilePack::LoadPackFile( char *fname, int encode, int dpmoffset, int slot)
 
 	p = (HFPHED *)_MALLOC( hedsize );
 	ff=hsp3_fopen(dpmname, dpmoffset);
-	if (ff == NULL) return -2;
+	if (ff == NULL) {
+		_FREE(p);
+		return -2;
+	}
 	hsp3_fread( ff, p, hedsize );
 	hsp3_fclose(ff);
 

--- a/src/hsp3dish/essprite.cpp
+++ b/src/hsp3dish/essprite.cpp
@@ -1895,7 +1895,10 @@ int essprite::draw(int start, int num, int mode, int start_pri, int end_pri)
 	a1 = start; a2 = num;
 	if (a1 < 0) a1 = 0;
 	if (a2 < 0) a2 = spkaz;
-	if (a1 >= spkaz) return -1;
+	if (a1 >= spkaz) {
+		delete [] selspr;
+		return -1;
+	}
 	if ((a1 + a2) >= spkaz) a2 = spkaz-a1;
 
 	if ((start_pri >= 0) && (end_pri >= 0)) {

--- a/src/hspcmp/token.cpp
+++ b/src/hspcmp/token.cpp
@@ -243,7 +243,7 @@ int CToken::AddPackfile( char *name, int mode )
 		strcat(fname, p_fname);
 	}
 	else {
-		strcat(fname, name);
+		strcpy(fname, name);
 	}
 
 	strcpy( packadd, fname);
@@ -307,7 +307,7 @@ int CToken::AddPackfileOrig(char* name, int mode)
 		strcat(fname, p_fname);
 	}
 	else {
-		strcat(fname, name);
+		strcpy(fname, name);
 	}
 
 	strcpy(packadd, fname);


### PR DESCRIPTION
実害があるか分かりませんがpack系の命令で絶対パスを指定すると、未初期化変数アクセスで、直前のpackの値やゴミデータがpackfileに書き出されます。メモリの状態によってはコンパイラがクラッシュするかもしれません。

```hsp
#pack "C:\\programs\\hsp37b10\\hsp37beta\\readme.txt"
```
