### PR TITLE
Linux版等の外部プラグインのタイプID割り当てと初期化順序を修正

### DIFF
--- a/src/hsp3/hsp3code.cpp
+++ b/src/hsp3/hsp3code.cpp
@@ -2818,9 +2818,12 @@ HSP3TYPEINFO *code_gettypeinfo( int type )
 	}
 
 	if ( id >= tinfo_cur ) {
+		int old_cur = tinfo_cur;
 		tinfo_cur = id + 1;
 		hsp3tinfo = (HSP3TYPEINFO *)sbExpand( (char *)hsp3tinfo, sizeof(HSP3TYPEINFO) * tinfo_cur );
-		hsp3typeinit_default( id );
+		for ( int i = old_cur; i < tinfo_cur; i++ ) {
+			hsp3typeinit_default( i );
+		}
 	}
 	info = GetTypeInfoPtr( id );
 	return info;
@@ -3282,7 +3285,7 @@ void code_init( void )
 
 	//		プラグイン追加の準備
 	//
-	tinfo_cur = HSP3_TYPE_USER;
+	// tinfo_cur はビルトイン拡張が使用した値のまま残す (リセットしない)
 
 #ifdef HSPDEBUG
 	//		デバッグ情報の初期化

--- a/src/hsp3/linux/hsp3ext_linux.cpp
+++ b/src/hsp3/linux/hsp3ext_linux.cpp
@@ -261,6 +261,17 @@ static int termfunc_dllcmd( int option )
 	return 0;
 }
 
+void hsp3ext_initsys( HSP3TYPEINFO *info )
+{
+	//		システム情報の初期化のみ行う (hgio_init より前に呼ぶ必要がある)
+	hspctx = info->hspctx;
+	exinfo = info->hspexinfo;
+	type = exinfo->nptype;
+	val = exinfo->npval;
+	exflg = exinfo->npexflg;
+	InitSystemInformation();
+}
+
 void hsp3typeinit_dllcmd( HSP3TYPEINFO *info )
 {
 	hspctx = info->hspctx;

--- a/src/hsp3/linux/hsp3ext_linux.h
+++ b/src/hsp3/linux/hsp3ext_linux.h
@@ -9,6 +9,7 @@
 
 void hsp3typeinit_dllcmd( HSP3TYPEINFO *info );
 void hsp3typeinit_dllctrl( HSP3TYPEINFO *info );
+void hsp3ext_initsys( HSP3TYPEINFO *info );
 
 char *hsp3ext_sysinfo(int p2, int* res, char* outbuf);
 char* hsp3ext_getdir(int id);

--- a/src/hsp3/linux/hsp3extlib_ffi.cpp
+++ b/src/hsp3/linux/hsp3extlib_ffi.cpp
@@ -270,6 +270,7 @@ static int Hsp3ExtAddPlugin( void )
 	//		プラグインの登録
 	//
 	int i;
+	int typefunc_count = 0;
 	HSPHED *hed;
 	char *ptr;
 	char *libname;
@@ -297,9 +298,14 @@ static int Hsp3ExtAddPlugin( void )
 
 		libname = strp(hpi->libname);
 		funcname = strp(hpi->funcname);
-		info = code_gettypeinfo(-1);
-
 		if ( hpi->flag == HPIDAT_FLAG_TYPEFUNC ) {
+			int plugin_type = hpi->option;
+			if ( plugin_type < HSP3_TYPE_PLUGIN ) {
+				plugin_type = HSP3_TYPE_PLUGIN + typefunc_count;
+			}
+			info = code_gettypeinfo( plugin_type );
+			typefunc_count++;
+
 		 	hd = DllManager().load_library( libname );
 			if ( hd == NULL ) {
 #if defined(HSPUTF8) && defined(_WIN32)

--- a/src/hsp3/win32gui/hsp3extlib.cpp
+++ b/src/hsp3/win32gui/hsp3extlib.cpp
@@ -223,6 +223,7 @@ static int Hsp3ExtAddPlugin( void )
 	//		プラグインの登録
 	//
 	int i;
+	int typefunc_count = 0;
 	HSPHED *hed;
 	char *ptr;
 	char *libname;
@@ -250,9 +251,14 @@ static int Hsp3ExtAddPlugin( void )
 
 		libname = strp(hpi->libname);
 		funcname = strp(hpi->funcname);
-		info = code_gettypeinfo(-1);
-
 		if ( hpi->flag == HPIDAT_FLAG_TYPEFUNC ) {
+			int plugin_type = hpi->option;
+			if ( plugin_type < HSP3_TYPE_PLUGIN ) {
+				plugin_type = HSP3_TYPE_PLUGIN + typefunc_count;
+			}
+			info = code_gettypeinfo( plugin_type );
+			typefunc_count++;
+
 		 	hd = DllManager().load_library( libname );
 			if ( hd == NULL ) {
 #ifdef HSPUTF8

--- a/src/hsp3dish/linux/hsp3dish.cpp
+++ b/src/hsp3dish/linux/hsp3dish.cpp
@@ -446,7 +446,9 @@ static int hsp3dish_initwindow( engine* p_engine, int sx, int sy, int autoscale,
 		printf("Unable to set GLContext: %s\n", SDL_GetError());
 		return -1;
 	}
-	
+
+	// hgio_init の前にシステム情報 (modfilename 等) を初期化する
+	hsp3ext_initsys( code_gettypeinfo( TYPE_DLLFUNC ) );
 
 	// 描画APIに渡す
 	hgio_init( 0, sx, sy, p_engine );
@@ -635,9 +637,6 @@ int hsp3dish_init_sub( int sx, int sy, int autoscale )
 	res = hsp3dish_initwindow( NULL, sx, sy, autoscale, "HSPDish ver" hspver );
 	if (res) return res;
 
-	hsp3typeinit_dllcmd( code_gettypeinfo( TYPE_DLLFUNC ) );
-	hsp3typeinit_dllctrl( code_gettypeinfo( TYPE_DLLCTRL ) );
-
 #ifdef HSPDISHGP
 	//		Initalize gameplay
 	//
@@ -743,9 +742,6 @@ int hsp3dish_init( char *startfile )
 	hsp->SetCommandLinePrm( cl_cmdline );		// コマンドラインパラメーターを保存
 	hsp->SetModuleFilePrm( cl_modname );			// モジュール名を保存
 
-	hsp3typeinit_dllcmd( code_gettypeinfo( TYPE_DLLFUNC ) );
-	hsp3typeinit_dllctrl( code_gettypeinfo( TYPE_DLLCTRL ) );
-
 	// Slightly different SDL initialization
 	if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) {
 		hsp3dish_dialog("Unable to initialize SDL");
@@ -783,6 +779,10 @@ int hsp3dish_init( char *startfile )
 	tinfo->hspexinfo = exinfo;
 	hsp3typeinit_sock_extcmd( tinfo );
 	}
+
+	//		Load external plugins (after built-in types are registered)
+	hsp3typeinit_dllcmd( code_gettypeinfo( TYPE_DLLFUNC ) );
+	hsp3typeinit_dllctrl( code_gettypeinfo( TYPE_DLLCTRL ) );
 
 	//		Initalize DEVINFO
 	HSP3DEVINFO *devinfo;


### PR DESCRIPTION
https://github.com/onitama/OpenHSP/issues/62 こちらの件の追加修正です。

- 外部プラグインのタイプID割り当てをコンパイラ(hspcmp)に合わせてHSP3_TYPE_PLUGIN(100)開始に統一
- code_initでのtinfo_curリセットを廃止し、ビルトイン拡張(sock等)のタイプ情報上書きを防止
- code_gettypeinfoで大きなタイプID指定時に中間スロットをデフォルト初期化して安全性を確保
- hsp3dishでシステム情報初期化(hsp3ext_initsys)を先行呼び出しし、外部プラグインのロードはビルトイン型登録後に実行するように修正