### PR TITLE
Fix hsp3gp Unicode launch paths

### DIFF
--- a/src/hsp3/hsp3pathio.cpp
+++ b/src/hsp3/hsp3pathio.cpp
@@ -193,6 +193,7 @@ int hsp_path_get_hsptv_path_utf8(std::string& result, hsp_path::utf8_view direct
 #if defined(HSPWIN) || defined(_WIN32)
 
 #include <windows.h>
+#include <shellapi.h>
 #include <sys/stat.h>
 
 static wchar_t* hsp_path_utf8_to_wide(const char* text)
@@ -250,6 +251,18 @@ static int hsp_path_narrow_from_wide_strict(std::string& result, const wchar_t* 
 int hsp_path_utf8_from_wide(std::string& result, const wchar_t* text)
 {
 	return hsp_path_narrow_from_wide_strict(result, text, utf16_to_utf8_strict);
+}
+
+int hsp_path_get_command_line_argument_utf8(std::string& result, int index)
+{
+	result.clear();
+	if (index < 0) return -1;
+	int count = 0;
+	wchar_t** arguments = CommandLineToArgvW(GetCommandLineW(), &count);
+	if (arguments == NULL) return -1;
+	int status = index < count ? hsp_path_utf8_from_wide(result, arguments[index]) : -1;
+	LocalFree(arguments);
+	return status;
 }
 
 static int hsp_path_enumerate_utf8(hsp_path::utf8_view pattern, int flags, hsp_path_list_callback callback, void* user_data)

--- a/src/hsp3/hsp3pathio.h
+++ b/src/hsp3/hsp3pathio.h
@@ -59,6 +59,9 @@ int hsp_path_get_module_filename_utf8(std::string& result);
 int hsp_path_get_module_filename_utf8(std::string& result, void* module);
 int hsp_path_get_module_directory_utf8(std::string& result);
 int hsp_path_get_current_directory_utf8(std::string& result);
+// Return one process command-line argument as UTF-8.
+// Returns zero on success and -1 when the index or command line is unavailable.
+int hsp_path_get_command_line_argument_utf8(std::string& result, int index);
 int hsp_path_get_hsptv_path_utf8(std::string& result, hsp_path::utf8_view name);
 int hsp_path_get_hsptv_path_utf8(std::string& result, hsp_path::ansi_view name);
 

--- a/src/hsp3/win32/main.cpp
+++ b/src/hsp3/win32/main.cpp
@@ -11,9 +11,7 @@
 #include "hsp3cl.h"
 
 #ifdef HSPUTF8
-#include <windows.h>
-#include <shellapi.h>
-#include "../hsp3utfcnv.h"
+#include "../hsp3pathio.h"
 #endif
 
 /*----------------------------------------------------------*/
@@ -21,36 +19,22 @@
 int main( int argc, char *argv[] )
 {
 	int res;
-	char *p;
-#ifdef HSPUTF8
-	LPWSTR *szArglist = NULL;
-	int nArgs = 0;
-	char utf8filename[4096];
+	const char *p;
+#if defined(HSPDEBUG) && defined(HSPUTF8)
+	std::string startfile;
 #endif
 
 #ifdef HSPDEBUG
 	if ( argc > 1 ) p = argv[ 1 ]; else p = "";
 #ifdef HSPUTF8
-	szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
-	if (szArglist) {
-		if (nArgs > 1) {
-			if (utf16_to_hsp3(utf8filename, szArglist[1], 4095)) {
-				p = utf8filename;
-			}
-			else {
-				p = "";
-			}
-		}
-	}
+	if (hsp_path_get_command_line_argument_utf8(startfile, 1) == 0) p = startfile.c_str();
+	else p = "";
 #endif
 #else
 	p = NULL;
 #endif
 
 	res = hsp3cl_init( p );
-#ifdef HSPUTF8
-	if (szArglist) LocalFree(szArglist);
-#endif
 	if ( res ) return res;
 	res = hsp3cl_exec();
 

--- a/src/hsp3/win32gui/main.cpp
+++ b/src/hsp3/win32gui/main.cpp
@@ -16,10 +16,7 @@
 #include "hsp3win.h"
 
 #ifdef HSPUTF8
-#include <shellapi.h>
-#include "../hsp3utfcnv.h"
-static LPWSTR* szArglist;
-static int nArgs;
+#include "../hsp3pathio.h"
 #endif
 
 /*----------------------------------------------------------*/
@@ -32,17 +29,12 @@ int APIENTRY WinMain ( HINSTANCE hInstance,
 	int res;
 #ifdef HSPDEBUG
 #ifdef HSPUTF8
-	char* sptr = lpCmdParam;
-	char utf8filename[4096];
-	szArglist = CommandLineToArgvW(GetCommandLineW(), &nArgs);
-	if (szArglist) {
-		if (nArgs > 1) {
-			utf16_to_hsp3(utf8filename, szArglist[1], 4095);
-			sptr = utf8filename;
-		}
+	std::string startfile;
+	const char *sptr = "";
+	if (hsp_path_get_command_line_argument_utf8(startfile, 1) == 0) {
+		sptr = startfile.c_str();
 	}
-	res = hsp3win_init( hInstance, sptr);
-	LocalFree(szArglist);
+	res = hsp3win_init(hInstance, sptr);
 #else
 	char fname[_MAX_PATH + 1];
 	char *ss = lpCmdParam;

--- a/src/hsp3dish/win32gp/hsp3dish.cpp
+++ b/src/hsp3dish/win32gp/hsp3dish.cpp
@@ -1045,13 +1045,13 @@ int hsp3dish_setwindow(int bootprm, int wx, int wy)
 	return 0;
 }
 
-int hsp3dish_init(HINSTANCE hInstance, char *startfile, HWND hParent)
+int hsp3dish_init(HINSTANCE hInstance, const char *startfile, HWND hParent)
 {
 	//		HSP3Dishシステム関連の初期化
 	//
 	int orgexe, mode;
+#if defined(HSPDEBUG) && !defined(HSPUTF8)
 	char *ss;
-#ifdef HSPDEBUG
 	int i;
 #endif
 
@@ -1075,19 +1075,28 @@ int hsp3dish_init(HINSTANCE hInstance, char *startfile, HWND hParent)
 	h_dbgwin = NULL;
 	dbgwnd = NULL;
 
-	ss = strsp_cmds(startfile);
-	i = (int)(ss - startfile);
-	ss = startfile;
-	if (ss[i - 1] == 32) i--;
-	if (*ss == 0x22) {
-		ss++; i -= 2;
+#ifdef HSPUTF8
+	if (startfile != NULL) {
+		hsp->SetFileName(startfile);
 	}
-	if (i > 0) {
-		char fname2[_MAX_PATH + 1];
-		strncpy(fname2, ss, i);
-		fname2[i] = 0;
-		hsp->SetFileName(fname2);
+#else
+	if (startfile != NULL) {
+		ss = strsp_cmds(const_cast<char *>(startfile));
+		i = (int)(ss - startfile);
+		ss = const_cast<char *>(startfile);
+		if (i > 0 && ss[i - 1] == 32) i--;
+		if (*ss == 0x22) {
+			ss++;
+			i = i >= 2 ? i - 2 : 0;
+		}
+		if (i > 0) {
+			char fname2[_MAX_PATH + 1];
+			strncpy(fname2, ss, i);
+			fname2[i] = 0;
+			hsp->SetFileName(fname2);
+		}
 	}
+#endif
 #else
 	if (startfile != NULL) {
 		hsp->SetFileName(startfile);

--- a/src/hsp3dish/win32gp/hsp3dish.h
+++ b/src/hsp3dish/win32gp/hsp3dish.h
@@ -9,7 +9,7 @@ int app_init(void);
 void app_bye(void);
 
 int hsp3dish_exec( void );
-int hsp3dish_init( HINSTANCE hInstance, char *startfile, HWND hParent );
+int hsp3dish_init( HINSTANCE hInstance, const char *startfile, HWND hParent );
 int hsp3dish_reset(void);
 int hsp3dish_setwindow(int bootprm, int wx, int wy);
 void hsp3dish_bye(void);

--- a/src/hsp3dish/win32gp/main.cpp
+++ b/src/hsp3dish/win32gp/main.cpp
@@ -14,6 +14,10 @@
 
 #include "hsp3dish.h"
 
+#ifdef HSPUTF8
+#include "../../hsp3/hsp3pathio.h"
+#endif
+
 /*----------------------------------------------------------*/
 
 #ifndef HSP3DLL
@@ -28,7 +32,16 @@ int APIENTRY WinMain ( HINSTANCE hInstance,
 	if (res) return res;
 
 #ifdef HSPDEBUG
+#ifdef HSPUTF8
+	std::string startfile;
+	const char *sptr = "";
+	if (hsp_path_get_command_line_argument_utf8(startfile, 1) == 0) {
+		sptr = startfile.c_str();
+	}
+	res = hsp3dish_init(hInstance, sptr, NULL);
+#else
 	res = hsp3dish_init( hInstance, lpCmdParam, NULL);
+#endif
 #else
 	res = hsp3dish_init( hInstance, NULL, NULL);
 #endif
@@ -182,11 +195,4 @@ EXPORT BOOL WINAPI hspexec(int p1, int p2, int p3, int p4)
 {
 	return 0;
 }
-
-
-
-
 #endif
-
-
-

--- a/test/test_hsp3pathio.cpp
+++ b/test/test_hsp3pathio.cpp
@@ -76,6 +76,13 @@ int main()
 	std::string current_directory;
 	assert(hsp_path_get_current_directory(current_directory) == 0);
 	assert(!current_directory.empty());
+	std::string command_line_argument;
+	assert(hsp_path_get_command_line_argument_utf8(command_line_argument, 0) == 0);
+	assert(!command_line_argument.empty());
+	assert(hsp_path_get_command_line_argument_utf8(command_line_argument, -1) != 0);
+	assert(command_line_argument.empty());
+	assert(hsp_path_get_command_line_argument_utf8(command_line_argument, 9999) != 0);
+	assert(command_line_argument.empty());
 	std::string native_hsptv_path;
 	assert(hsp_path_get_hsptv_path(native_hsptv_path,
 		hsp_path::path_view("native-test.dat")) == 0);


### PR DESCRIPTION
hgimg4だけユニコードパスでの起動対応が抜けていました。
hsp3とやhsp3clと共通化して修正しました。